### PR TITLE
Simplify bin flags

### DIFF
--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -14,7 +14,10 @@ const { version } = require('../package')
 const logError = require('../lib/error')
 
 const flags = mri(process.argv.slice(2), {
-  string: ['host', 'port'],
+  default: {
+    host: '::',
+    port: 3000
+  },
   alias: {
     p: 'port',
     H: 'host',

--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -15,7 +15,6 @@ const logError = require('../lib/error')
 
 const flags = mri(process.argv.slice(2), {
   string: ['host', 'port'],
-  boolean: ['help', 'version'],
   alias: {
     p: 'port',
     H: 'host',

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -16,7 +16,7 @@ module.exports = async (file, flags, restarting) => {
   const server = serve(module)
 
   // `3000` is the default port
-  let port = parseInt(flags.port, 10) || 3000
+  let port = ~~flags.port
 
   // Check if the specified port is already in use (if none
   // is specified, the default one will be checked)


### PR DESCRIPTION
To go along with https://github.com/zeit/micro/pull/291

The `~~flags.port` isn't _really_ necessary, but I kept the parsing just in case someone does something funky with their `$PORT`; eg a double-quoted `'"8080"'`.