### PR TITLE
Added `--cold`, `--watch` and `--poll` flags

### DIFF
--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -21,7 +21,7 @@ const flags = mri(process.argv.slice(2), {
   alias: {
     p: 'port',
     H: 'host',
-    n: 'nowatch',
+    c: 'cold',
     w: 'watch',
     L: 'poll',
     h: 'help',
@@ -48,8 +48,11 @@ if (flags.version) {
   process.exit()
 }
 
-if (flags.nowatch && (flags.watch || flags.poll)) {
-  logError('The --nowatch flag is not compatible with --watch or --poll!')
+if (flags.cold && (flags.watch || flags.poll)) {
+  logError(
+    'The --cold flag is not compatible with --watch or --poll!',
+    'watch-flags'
+  )
   process.exit(1)
 }
 

--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -21,6 +21,9 @@ const flags = mri(process.argv.slice(2), {
   alias: {
     p: 'port',
     H: 'host',
+    n: 'nowatch',
+    w: 'watch',
+    L: 'poll',
     h: 'help',
     v: 'version'
   },
@@ -43,6 +46,11 @@ if (flags.help) {
 if (flags.version) {
   console.log(version)
   process.exit()
+}
+
+if (flags.nowatch && (flags.nowatch || flags.poll)) {
+  logError('The --nowatch flag is not compatible with --watch or --poll!')
+  process.exit(1)
 }
 
 let file = flags._[0]

--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -48,7 +48,7 @@ if (flags.version) {
   process.exit()
 }
 
-if (flags.nowatch && (flags.nowatch || flags.poll)) {
+if (flags.nowatch && (flags.watch || flags.poll)) {
   logError('The --nowatch flag is not compatible with --watch or --poll!')
   process.exit(1)
 }

--- a/errors/watch-flags.md
+++ b/errors/watch-flags.md
@@ -1,0 +1,9 @@
+# Too Many Watch Flags
+
+#### Why This Error Occurred
+
+When you ran the `micro-dev` command with the `--cold` flag (which disables hot reloading), you've defined more flags that are also related to hot reloading. This is not allowed!
+
+#### Possible Ways to Fix It
+
+When using `--cold`, you cannot use `--watch` or `--poll`. To use one of the latter two flags, you need to enable hot reloading (leave the `--cold` flag away).

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,4 +1,6 @@
 module.exports = (message, errorCode) => {
+  const repo = errorCode === 'watch-flags' ? 'micro-dev' : 'micro'
+
   console.error(message)
-  console.error(`Read more here: https://err.sh/micro/${errorCode}`)
+  console.error(`Read more here: https://err.sh/${repo}/${errorCode}`)
 }

--- a/lib/help.js
+++ b/lib/help.js
@@ -10,9 +10,7 @@ module.exports = () => {
     ${g('-H, --host')}          The host on which micro will run
     ${g('-n, --no-watch')}      Disable file watching
     ${g('-w, --watch <dir>')}   A directory to watch in addition to [path]
-    ${g(
-      '-L, --poll'
-    )}          Poll for file system changes rather than using events
+    ${g('-L, --poll')}          Poll for code changes rather than using events
     ${g('-v, --version')}       Output the version number
     ${g('-h, --help')}          Show this usage information
   `

--- a/lib/help.js
+++ b/lib/help.js
@@ -6,10 +6,13 @@ module.exports = () => {
 
   Options:
 
-    ${green('-p, --port <n>')}  Port to listen on (defaults to 3000)
-    ${green('-H, --host')}      The host on which micro will run
-    ${green('-v, --version')}   Output the version number
-    ${green('-h, --help')}      Show this usage information
+    ${green('-p, --port <n>')}    Port to listen on (defaults to 3000)
+    ${green('-H, --host')}        The host on which micro will run
+    ${green('-n, --no-watch')}    Disable file watching
+    ${green('-w, --watch <dir>')} The directory to watch as well as the [path]
+    ${green('-L, --poll')}        Poll for changes rather than using events
+    ${green('-v, --version')}     Output the version number
+    ${green('-h, --help')}        Show this usage information
   `
 
   return usage

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,20 +1,20 @@
 // Packages
-const { green } = require('chalk')
+const { green: g } = require('chalk')
 
 module.exports = () => {
-  const usage = `\n  Usage: ${green('micro-dev')} [path] [options]
+  const usage = `\n  Usage: ${g('micro-dev')} [path] [options]
 
   Options:
 
-    ${green('-p, --port <n>')}      Port to listen on (defaults to 3000)
-    ${green('-H, --host')}          The host on which micro will run
-    ${green('-n, --no-watch')}      Disable file watching
-    ${green('-w, --watch <dir>')}   A directory to watch in addition to [path]
-    ${green(
+    ${g('-p, --port <n>')}      Port to listen on (defaults to 3000)
+    ${g('-H, --host')}          The host on which micro will run
+    ${g('-n, --no-watch')}      Disable file watching
+    ${g('-w, --watch <dir>')}   A directory to watch in addition to [path]
+    ${g(
       '-L, --poll'
     )}          Poll for file system changes rather than using events
-    ${green('-v, --version')}       Output the version number
-    ${green('-h, --help')}          Show this usage information
+    ${g('-v, --version')}       Output the version number
+    ${g('-h, --help')}          Show this usage information
   `
 
   return usage

--- a/lib/help.js
+++ b/lib/help.js
@@ -8,7 +8,7 @@ module.exports = () => {
 
     ${g('-p, --port <n>')}      Port to listen on (defaults to 3000)
     ${g('-H, --host')}          The host on which micro will run
-    ${g('-n, --no-watch')}      Disable file watching
+    ${g('-c, --cold')}          Disable hot reloading
     ${g('-w, --watch <dir>')}   A directory to watch in addition to [path]
     ${g('-L, --poll')}          Poll for code changes rather than using events
     ${g('-v, --version')}       Output the version number

--- a/lib/help.js
+++ b/lib/help.js
@@ -6,13 +6,15 @@ module.exports = () => {
 
   Options:
 
-    ${green('-p, --port <n>')}    Port to listen on (defaults to 3000)
-    ${green('-H, --host')}        The host on which micro will run
-    ${green('-n, --no-watch')}    Disable file watching
-    ${green('-w, --watch <dir>')} The directory to watch as well as the [path]
-    ${green('-L, --poll')}        Poll for changes rather than using events
-    ${green('-v, --version')}     Output the version number
-    ${green('-h, --help')}        Show this usage information
+    ${green('-p, --port <n>')}      Port to listen on (defaults to 3000)
+    ${green('-H, --host')}          The host on which micro will run
+    ${green('-n, --no-watch')}      Disable file watching
+    ${green('-w, --watch <dir>')}   A directory to watch in addition to [path]
+    ${green(
+      '-L, --poll'
+    )}          Poll for file system changes rather than using events
+    ${green('-v, --version')}       Output the version number
+    ${green('-h, --help')}          Show this usage information
   `
 
   return usage

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -69,37 +69,50 @@ module.exports = async (server, inUse, flags, sockets) => {
   const url = `http://${ipAddress}:${details.port}`
   const { isTTY } = process.stdout
   const file = flags._[0]
+  const watching_enabled = flags.nowatch ? false : true
+  const usePolling = flags.poll
+  let toWatch = flags.watch || false
 
-  const watchConfig = {
-    ignoreInitial: true,
-    ignored: /.git|node_modules|.nyc_output|.sass-cache|coverage/
-  }
-
-  const ignoredExtensions = ['swp']
-
-  // Find out which directory to watch
-  const closestPkg = await pkgUp(path.dirname(file))
-  const toWatch = closestPkg ? path.dirname(closestPkg) : process.cwd()
-
-  // Start watching the project files
-  const watcher = watch(toWatch, watchConfig)
-
-  // Ensure that the server gets restarted if a file changes
-  watcher.on('all', (event, filePath) => {
-    const location = path.relative(process.cwd(), filePath)
-    const extension = path.extname(location).split('.')[1]
-
-    if (ignoredExtensions.includes(extension)) {
-      return
+  if (watching_enabled) {
+    const watchConfig = {
+      usePolling,
+      ignoreInitial: true,
+      ignored: /.git|node_modules|.nyc_output|.sass-cache|coverage/
     }
 
-    console.log(
-      `\n${chalk.blue('File changed:')} ${location} - Restarting server...`
-    )
+    const ignoredExtensions = ['swp']
 
-    destroySockets(sockets)
-    server.close(restartServer.bind(this, file, flags, watcher))
-  })
+    if (Array.isArray(toWatch)) {
+      toWatch.push(file)
+    } else if (toWatch) {
+      toWatch = [toWatch, file]
+    } else {
+      // Find out which directory to watch
+      const closestPkg = await pkgUp(path.dirname(file))
+      toWatch = [closestPkg ? path.dirname(closestPkg) : process.cwd()]
+    }
+
+    // Start watching the project files
+    const watcher = watch(toWatch, watchConfig)
+
+    // Ensure that the server gets restarted if a file changes
+    watcher.on('all', (event, filePath) => {
+      const location = path.relative(process.cwd(), filePath)
+      const extension = path.extname(location).split('.')[1]
+
+      if (ignoredExtensions.includes(extension)) {
+        return
+      }
+
+      console.log(
+        `\n${chalk.blue('File changed:')} ${location} - Restarting server...`
+      )
+
+      destroySockets(sockets)
+      server.close(restartServer.bind(this, file, flags, watcher))
+    })
+  }
+
 
   if (flags.restarted) {
     console.log(chalk.green('Restarted!'))

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -69,11 +69,11 @@ module.exports = async (server, inUse, flags, sockets) => {
   const url = `http://${ipAddress}:${details.port}`
   const { isTTY } = process.stdout
   const file = flags._[0]
-  const watching_enabled = flags.nowatch ? false : true
+  const watchingEnabled = !flags.nowatch
   const usePolling = flags.poll
   let toWatch = flags.watch || false
 
-  if (watching_enabled) {
+  if (watchingEnabled) {
     const watchConfig = {
       usePolling,
       ignoreInitial: true,

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -69,13 +69,12 @@ module.exports = async (server, inUse, flags, sockets) => {
   const url = `http://${ipAddress}:${details.port}`
   const { isTTY } = process.stdout
   const file = flags._[0]
-  const watchingEnabled = !flags.nowatch
-  const usePolling = flags.poll
-  let toWatch = flags.watch || false
 
-  if (watchingEnabled) {
+  if (!flags.cold) {
+    let toWatch = flags.watch || false
+
     const watchConfig = {
-      usePolling,
+      usePolling: flags.poll,
       ignoreInitial: true,
       ignored: /.git|node_modules|.nyc_output|.sass-cache|coverage/
     }
@@ -112,7 +111,6 @@ module.exports = async (server, inUse, flags, sockets) => {
       server.close(restartServer.bind(this, file, flags, watcher))
     })
   }
-
 
   if (flags.restarted) {
     console.log(chalk.green('Restarted!'))


### PR DESCRIPTION
This adds --watch, --nowatch, and --poll to the options that
micro-dev can accept.

* --nowatch disables watching entirely
    In case you do not want to watch the file system for changes at
    all, as in #10
* --watch allows passing directories to be watched, ignoring others
    In case you have only one or a few directories to be watched,
    and churn in others, you can do, e.g. `-w lib -w test`
* --poll uses chokidar's polling method rather than filesystem events
    In case you are doing local development across an NFS mount or in
    a shared volume from a docker container, using -L will enable
    watching to work anyway.  The -L is used as the short form because
    nodemon uses it for the same purpose, and we can't use -p as that
    is already in use for --port.