### PR TITLE
Let the user use his own NODE_ENV

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -9,7 +9,7 @@ const log = require('./log')
 
 module.exports = async (file, flags, restarting) => {
   // Ensure that the loaded files have the correct env
-  process.env.NODE_ENV = 'development'
+  process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
   // And then load the files
   const module = log(getModule(file))


### PR DESCRIPTION
If a NODE_ENV is already defined, do not overwrite it supposing `development` is the desired one.