### PR TITLE
Add ignore option for watching files

### DIFF
--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -25,7 +25,8 @@ const flags = mri(process.argv.slice(2), {
     w: 'watch',
     L: 'poll',
     h: 'help',
-    v: 'version'
+    v: 'version',
+    i: 'ignore'
   },
   unknown(flag) {
     console.log(`The option "${flag}" is unknown. Use one of these:`)

--- a/lib/help.js
+++ b/lib/help.js
@@ -11,6 +11,7 @@ module.exports = () => {
     ${g('-c, --cold')}          Disable hot reloading
     ${g('-w, --watch <dir>')}   A directory to watch in addition to [path]
     ${g('-L, --poll')}          Poll for code changes rather than using events
+    ${g('-i  --ignore <dir>')}  Ignore watching a file, directory, or glob
     ${g('-v, --version')}       Output the version number
     ${g('-h, --help')}          Show this usage information
   `

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -8,6 +8,7 @@ const chalk = require('chalk')
 const boxen = require('boxen')
 const { watch } = require('chokidar')
 const pkgUp = require('pkg-up')
+const anymatch = require('anymatch')
 
 const copyToClipboard = async text => {
   try {
@@ -94,12 +95,24 @@ module.exports = async (server, inUse, flags, sockets) => {
     // Start watching the project files
     const watcher = watch(toWatch, watchConfig)
 
+    // Ignore globs, files, and directories
+    const ignored = [].concat(flags.ignore).map(x => {
+      const glob = x.toString()
+      if (glob.endsWith(path.sep) || glob.endsWith('/')) {
+        return glob + '**'
+      }
+      return glob
+    })
+
     // Ensure that the server gets restarted if a file changes
     watcher.on('all', (event, filePath) => {
       const location = path.relative(process.cwd(), filePath)
       const extension = path.extname(location).split('.')[1]
 
-      if (ignoredExtensions.includes(extension)) {
+      if (
+        ignoredExtensions.includes(extension) ||
+        anymatch(ignored, location)
+      ) {
         return
       }
 

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -103,6 +103,7 @@ module.exports = async (server, inUse, flags, sockets) => {
       }
       return glob
     })
+    watcher.unwatch(ignored)
 
     // Ensure that the server gets restarted if a file changes
     watcher.on('all', (event, filePath) => {

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -8,7 +8,6 @@ const chalk = require('chalk')
 const boxen = require('boxen')
 const { watch } = require('chokidar')
 const pkgUp = require('pkg-up')
-const anymatch = require('anymatch')
 
 const copyToClipboard = async text => {
   try {
@@ -77,10 +76,16 @@ module.exports = async (server, inUse, flags, sockets) => {
     const watchConfig = {
       usePolling: flags.poll,
       ignoreInitial: true,
-      ignored: /.git|node_modules|.nyc_output|.sass-cache|coverage/
+      ignored: [
+        /\.git|node_modules|\.nyc_output|\.sass-cache|coverage/,
+        /\.swp$/
+      ]
     }
 
-    const ignoredExtensions = ['swp']
+    // Ignore globs
+    if (flags.ignore) {
+      watchConfig.ignored = watchConfig.ignored.concat(flags.ignore)
+    }
 
     if (Array.isArray(toWatch)) {
       toWatch.push(file)
@@ -95,27 +100,9 @@ module.exports = async (server, inUse, flags, sockets) => {
     // Start watching the project files
     const watcher = watch(toWatch, watchConfig)
 
-    // Ignore globs, files, and directories
-    const ignored = [].concat(flags.ignore).filter(x => x).map(x => {
-      const glob = x.toString()
-      if (glob.endsWith(path.sep) || glob.endsWith('/')) {
-        return glob + '**'
-      }
-      return glob
-    })
-    watcher.unwatch(ignored)
-
     // Ensure that the server gets restarted if a file changes
     watcher.on('all', (event, filePath) => {
       const location = path.relative(process.cwd(), filePath)
-      const extension = path.extname(location).split('.')[1]
-
-      if (
-        ignoredExtensions.includes(extension) ||
-        anymatch(ignored, location)
-      ) {
-        return
-      }
 
       console.log(
         `\n${chalk.blue('File changed:')} ${location} - Restarting server...`

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -96,7 +96,7 @@ module.exports = async (server, inUse, flags, sockets) => {
     const watcher = watch(toWatch, watchConfig)
 
     // Ignore globs, files, and directories
-    const ignored = [].concat(flags.ignore).map(x => {
+    const ignored = [].concat(flags.ignore).filter(x => x).map(x => {
       const glob = x.toString()
       if (glob.endsWith(path.sep) || glob.endsWith('/')) {
         return glob + '**'

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "API"
   ],
   "dependencies": {
-    "anymatch": "1.3.2",
     "boxen": "1.2.1",
     "chalk": "2.0.1",
     "chokidar": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "API"
   ],
   "dependencies": {
+    "anymatch": "1.3.2",
     "boxen": "1.2.1",
     "chalk": "2.0.1",
     "chokidar": "1.7.0",


### PR DESCRIPTION
In my local setup, I had a local test database instance running in a folder `./db`. When I run my server, the database touches some files in that temporary folder, and micro-dev restarts over and over again every time the file is touched. I added this option so I could prevent changes in db from restarting the server.

I tried using chokidar's `FSWatcher.unwatch`, but could not get it to work.