### PR TITLE
Correctly override res.end

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -91,9 +91,10 @@ let requestCounter = 0
 const initLog = (req, res) => {
   const start = new Date()
   const requestIndex = ++requestCounter
+
   const end = res.end
 
-  res.end = async (chunk, encoding) => {
+  res.end = (chunk, encoding, callback) => {
     res.end = end
     const endTime = new Date()
     const delta = endTime - start
@@ -102,17 +103,18 @@ const initLog = (req, res) => {
 
     console.log(chalk.grey(`\n${'—'.repeat(process.stdout.columns)}\n`))
 
-    await logRequest({ req, start, requestIndex })
-    await logResponse({
-      res,
-      start,
-      end: requestTime,
-      endTime,
-      requestIndex,
-      chunk
+    logRequest({ req, start, requestIndex }).then(() => {
+      logResponse({
+        res,
+        start,
+        end: requestTime,
+        endTime,
+        requestIndex,
+        chunk
+      })
     })
 
-    res.end(chunk, encoding)
+    return res.end(chunk, encoding, callback)
   }
 }
 
@@ -125,6 +127,6 @@ module.exports = fn => async (req, res) => {
     res.microErr = err
 
     const { statusCode = 500, stack } = err
-    send(res, statusCode, stack)
+    return send(res, statusCode, stack)
   }
 }


### PR DESCRIPTION
`res.end` is not an async function, therefore it cannot be overridden with an async function.
In that case its behavior change and the original `res.end` would be called too late. There is no need to make this function async because what we want to do is to log something at the end. And then, this function should return whatever the original one returns, and it should pass the original parameters so this modification is done too.
The correct way I think is to use the `finish` event of the res object instead but this event misses the needed information.
Meanwhile this close #12