### PR TITLE
fix: remove watcher.close and use watcher.once

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -36,9 +36,6 @@ const restartServer = (file, flags, watcher) => {
     }
   }
 
-  // Stop watching any files
-  watcher.close()
-
   // Remove file that changed from the `require` cache
   for (const item of toDelete) {
     let location
@@ -102,7 +99,7 @@ module.exports = async (server, inUse, flags, sockets) => {
     const watcher = watch(toWatch, watchConfig)
 
     // Ensure that the server gets restarted if a file changes
-    watcher.on(
+    watcher.once(
       'all',
       debounce((event, filePath) => {
         const location = path.relative(process.cwd(), filePath)


### PR DESCRIPTION
calling chokidar's `watch()` on a same file multiple times doesn't
necessarily create multiple background watchers. These calls and
`watcher.close()` calls might cause a race-condition bug that stops the
seemingly newly created watcher.

this fix will not remove the need to use debounce because we need to
make sure multiple file changes happen simultaneously (usually due to a
build pipeline) will not result in an inconsistent state.