### PR TITLE
fix: log in/out bodies for requests that have body parsed with `json()`

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -92,6 +92,10 @@ const initLog = (req, res) => {
   const start = new Date()
   const requestIndex = ++requestCounter
 
+  console.log(chalk.grey(`\n${'—'.repeat(process.stdout.columns)}\n`))
+
+  const reqBodyReady = logRequest({ req, start, requestIndex })
+
   const end = res.end
 
   res.end = (chunk, encoding, callback) => {
@@ -101,9 +105,7 @@ const initLog = (req, res) => {
     const requestTime =
       delta < 10000 ? `${delta}ms` : `${Math.round(delta / 1000)}s`
 
-    console.log(chalk.grey(`\n${'—'.repeat(process.stdout.columns)}\n`))
-
-    logRequest({ req, start, requestIndex }).then(() => {
+    reqBodyReady.then(() =>
       logResponse({
         res,
         start,
@@ -112,7 +114,7 @@ const initLog = (req, res) => {
         requestIndex,
         chunk
       })
-    })
+    )
 
     return res.end(chunk, encoding, callback)
   }


### PR DESCRIPTION
`json()` calls will never be resolved in `res.end`

close #33