### PR TITLE
Take note of the required Node.js version to run micro-dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ When preparing your development environment, firstly install `micro-dev`:
 npm install --save-dev micro-dev
 ```
 
+**Note:** You'll need at least Node.js v7.6.0 to run `micro-dev`.
+
 Next, add a new `script` property below `micro` inside `package.json`:
 
 ```json


### PR DESCRIPTION
I ran into the same issue as mentioned in #36. 

@leo mentioned the Node.js version was too low:

> Your Node.js version is not supported. Please upgrade to the latest one 😊

A small message saying you should use Node.js v7.6 or newer would make a difference.
See http://node.green/#ES2017-features-async-functions for more details.

You could already use it starting from Node.js v7.0.0 but you need to specify the `--harmony` flag.

**Nice to have:** I guess you could also extend the micro-dev package.json with the [engines](https://docs.npmjs.com/files/package.json#engines) config? 
