### PR TITLE
Improve ignore files

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -1,4 +1,5 @@
 // Native
+const { existsSync, statSync } = require('fs')
 const path = require('path')
 
 // Packages
@@ -12,6 +13,8 @@ const chalk = require('chalk')
 const boxen = require('boxen')
 const ip = require('ip')
 
+const isDirSync = path => existsSync(path) && statSync(path).isDirectory()
+
 const getIgnoredFiles = ({ flags, gitignore, pkg }) => {
   const set = new Set()
   const addIgnore = value => set.add(value)
@@ -21,7 +24,15 @@ const getIgnoredFiles = ({ flags, gitignore, pkg }) => {
   if (pkg.ignore) pkg.ignore.forEach(addIgnore)
   ignoredDirectories.forEach(addIgnore)
 
-  return Array.from(set)
+  const rawIgnored = Array.from(set)
+
+  const ignored = rawIgnored.reduce((acc, ignore) => {
+    const file = path.resolve(process.cwd(), ignore)
+    acc.push(isDirSync(file) ? `**/${path.basename(file)}/**` : ignore)
+    return acc
+  }, [])
+
+  return { ignored, rawIgnored }
 }
 
 const copyToClipboard = async text => {
@@ -88,7 +99,7 @@ module.exports = async (server, inUse, flags, sockets) => {
     // Find out which directory to watch
     const closestPkg = await pkgUp(path.dirname(file))
     const gitignore = path.join(path.dirname(file, '.gitignore'))
-    const ignored = getIgnoredFiles({flags, gitignore, pkg: closestPkg})
+    const {ignored, rawIgnored} = getIgnoredFiles({flags, gitignore, pkg: closestPkg})
 
     const watchConfig = {
       usePolling: flags.poll,

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -12,10 +12,9 @@ const chalk = require('chalk')
 const boxen = require('boxen')
 const ip = require('ip')
 
-const getIgnoredFiles = ({ flags, pkg }) => {
+const getIgnoredFiles = ({ flags, gitignore, pkg }) => {
   const set = new Set()
   const addIgnore = value => set.add(value)
-  const gitignore = path.resolve(process.cwd(), '.gitignore')
 
   getIgnoredFromGit(gitignore).forEach(addIgnore)
   if (flags.ignore) flags.ignore.forEach(addIgnore)
@@ -88,7 +87,8 @@ module.exports = async (server, inUse, flags, sockets) => {
 
     // Find out which directory to watch
     const closestPkg = await pkgUp(path.dirname(file))
-    const ignored = getIgnoredFiles({flags, pkg: closestPkg})
+    const gitignore = path.join(path.dirname(file, '.gitignore'))
+    const ignored = getIgnoredFiles({flags, gitignore, pkg: closestPkg})
 
     const watchConfig = {
       usePolling: flags.poll,

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -1,14 +1,29 @@
 // Native
 const path = require('path')
-const debounce = require('debounce')
 
 // Packages
+const ignoredDirectories = require('ignore-by-default').directories()
 const { write: copy } = require('clipboardy')
-const ip = require('ip')
+const getIgnoredFromGit = require('ignored')
+const { watch } = require('chokidar')
+const debounce = require('debounce')
+const pkgUp = require('pkg-up')
 const chalk = require('chalk')
 const boxen = require('boxen')
-const { watch } = require('chokidar')
-const pkgUp = require('pkg-up')
+const ip = require('ip')
+
+const getIgnoredFiles = ({ flags, pkg }) => {
+  const set = new Set()
+  const addIgnore = value => set.add(value)
+  const gitignore = path.resolve(process.cwd(), '.gitignore')
+
+  getIgnoredFromGit(gitignore).forEach(addIgnore)
+  if (flags.ignore) flags.ignore.forEach(addIgnore)
+  if (pkg.ignore) pkg.ignore.forEach(addIgnore)
+  ignoredDirectories.forEach(addIgnore)
+
+  return Array.from(set)
+}
 
 const copyToClipboard = async text => {
   try {
@@ -71,18 +86,14 @@ module.exports = async (server, inUse, flags, sockets) => {
   if (!flags.cold) {
     let toWatch = flags.watch || false
 
+    // Find out which directory to watch
+    const closestPkg = await pkgUp(path.dirname(file))
+    const ignored = getIgnoredFiles({flags, pkg: closestPkg})
+
     const watchConfig = {
       usePolling: flags.poll,
       ignoreInitial: true,
-      ignored: [
-        /\.git|node_modules|\.nyc_output|\.sass-cache|coverage/,
-        /\.swp$/
-      ]
-    }
-
-    // Ignore globs
-    if (flags.ignore) {
-      watchConfig.ignored = watchConfig.ignored.concat(flags.ignore)
+      ignored
     }
 
     if (Array.isArray(toWatch)) {
@@ -90,8 +101,6 @@ module.exports = async (server, inUse, flags, sockets) => {
     } else if (toWatch) {
       toWatch = [toWatch, file]
     } else {
-      // Find out which directory to watch
-      const closestPkg = await pkgUp(path.dirname(file))
       toWatch = [closestPkg ? path.dirname(closestPkg) : process.cwd()]
     }
 

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -7,6 +7,7 @@ const ignoredDirectories = require('ignore-by-default').directories()
 const { write: copy } = require('clipboardy')
 const getIgnoredFromGit = require('ignored')
 const { watch } = require('chokidar')
+const anymatch = require('anymatch')
 const debounce = require('debounce')
 const pkgUp = require('pkg-up')
 const chalk = require('chalk')
@@ -44,9 +45,9 @@ const copyToClipboard = async text => {
   }
 }
 
-const restartServer = (file, flags, watcher) => {
+const restartServer = ({ file, flags, watcher, ignored }) => {
   const watched = watcher.getWatched()
-  const toDelete = []
+  let toDelete = []
 
   for (const mainPath in watched) {
     if (!{}.hasOwnProperty.call(watched, mainPath)) {
@@ -60,6 +61,11 @@ const restartServer = (file, flags, watcher) => {
       toDelete.push(full)
     }
   }
+
+  const matchers = anymatch(ignored)
+
+  // Remove ignored files
+  toDelete = toDelete.filter(filename => !matchers(path.basename(filename)))
 
   // Remove file that changed from the `require` cache
   for (const item of toDelete) {
@@ -98,8 +104,12 @@ module.exports = async (server, inUse, flags, sockets) => {
 
     // Find out which directory to watch
     const closestPkg = await pkgUp(path.dirname(file))
-    const gitignore = path.join(path.dirname(file, '.gitignore'))
-    const {ignored, rawIgnored} = getIgnoredFiles({flags, gitignore, pkg: closestPkg})
+    const gitignore = path.join(path.dirname(file), '.gitignore')
+    const { ignored, rawIgnored } = getIgnoredFiles({
+      flags,
+      gitignore,
+      pkg: closestPkg
+    })
 
     const watchConfig = {
       usePolling: flags.poll,
@@ -134,7 +144,14 @@ module.exports = async (server, inUse, flags, sockets) => {
         flags.port = details.port
 
         // Restart server
-        server.close(restartServer.bind(this, file, flags, watcher))
+        server.close(
+          restartServer.bind(this, {
+            file,
+            flags,
+            watcher,
+            ignored: rawIgnored
+          })
+        )
       }, 10)
     )
   }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "clipboardy": "1.1.4",
     "debounce": "1.0.2",
     "get-port": "3.1.0",
+    "ignore-by-default": "1.0.1",
+    "ignored": "2.0.4",
     "ip": "1.1.5",
     "jsome": "2.3.26",
     "micro": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "API"
   ],
   "dependencies": {
+    "anymatch": "1.3.2",
     "boxen": "1.2.1",
     "chalk": "2.1.0",
     "chokidar": "1.7.0",


### PR DESCRIPTION
Closes #27

- using `ignored` for get .gitignores files.
- using `ignore-by-default` to get common ignoring files.
- support pass ignore files from CLI
- add ignores files declared at package.jon
- Avoid reload ignored files