### PR TITLE
Set cli flags by corresponding env var prefixed with MICRO_DEV_

### DIFF
--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -13,10 +13,19 @@ const serve = require('../lib/serve')
 const { version } = require('../package')
 const logError = require('../lib/error')
 
+const environment = process.env
+
 const flags = mri(process.argv.slice(2), {
   default: {
-    host: '::',
-    port: 3000
+    host: environment.MICRO_DEV_HOST || '::',
+    port: environment.MICRO_DEV_PORT || 3000,
+    cold: environment.MICRO_DEV_COLD,
+    watch: environment.MICRO_DEV_WATCH,
+    poll: environment.MICRO_DEV_POLL,
+    silent: environment.MICRO_DEV_SILENT,
+    help: environment.MICRO_DEV_HELP,
+    version: environment.MICRO_DEV_VERSION,
+    ignore: environment.MICRO_DEV_IGNORE
   },
   alias: {
     p: 'port',


### PR DESCRIPTION
I'm running `micro-dev` inside a docker container using docker-compose, and couldn't find a way to configure `micro-dev`'s behavior using env vars (specifically, I needed a way to set the `--poll` flag by env var).

This PR adds this functionality in a rather boilerplatey, but simple way. I can refactor this to be more dynamic if that's what people prefer, i.e. programmatically generate env var names based on names of the available CLI flags.

Only somewhat related to https://github.com/zeit/micro-dev/issues/18. I don't personally use `now` or `dotenv` to store my env vars in files (I just specify them in docker-compose), but this PR should add another good use case for that feature if we want to support it eventually.