### PR TITLE
fix: hangs on parsing buffer/text/json

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -94,11 +94,10 @@ const initLog = (req, res) => {
 
   console.log(chalk.grey(`\n${'—'.repeat(process.stdout.columns)}\n`))
 
-  const reqBodyReady = logRequest({ req, start, requestIndex })
-
   const end = res.end
 
   res.end = (chunk, encoding, callback) => {
+    const reqBodyReady = logRequest({ req, start, requestIndex })
     res.end = end
     const endTime = new Date()
     const delta = endTime - start


### PR DESCRIPTION
Parsing `buffer`, `text` or `json` causes `micro-dev` to hang.
Closes zeit/micro-dev#41