### PR TITLE
Added flag to allow increasing the default 1mb limit for json parsing

### DIFF
--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -16,7 +16,8 @@ const logError = require('../lib/error')
 const flags = mri(process.argv.slice(2), {
   default: {
     host: '::',
-    port: 3000
+    port: 3000,
+    limit: '1mb'
   },
   alias: {
     p: 'port',
@@ -27,7 +28,8 @@ const flags = mri(process.argv.slice(2), {
     s: 'silent',
     h: 'help',
     v: 'version',
-    i: 'ignore'
+    i: 'ignore',
+    l: 'limit'
   },
   unknown(flag) {
     console.log(`The option "${flag}" is unknown. Use one of these:`)

--- a/lib/help.js
+++ b/lib/help.js
@@ -11,6 +11,7 @@ module.exports = () => {
     ${g('-c, --cold')}          Disable hot reloading
     ${g('-w, --watch <dir>')}   A directory to watch in addition to [path]
     ${g('-L, --poll')}          Poll for code changes rather than using events
+    ${g('-l, --limit')}         File size limit for JSON parsing. Specify as a string '1mb', or in bytes
     ${g('-i  --ignore <dir>')}  Ignore watching a file, directory, or glob
     ${g('-s, --silent')}        Disable requests log
     ${g('-v, --version')}       Output the version number

--- a/lib/log.js
+++ b/lib/log.js
@@ -32,12 +32,12 @@ const logLine = (message, date) => {
   console.log(`${message}${' '.repeat(logSpace)}${dateString}\n`)
 }
 
-const logRequest = async ({ req, start, requestIndex }) => {
+const logRequest = async ({ req, start, requestIndex, limit }) => {
   logLine(`> #${requestIndex} ${chalk.bold(req.method)} ${req.url}`, start)
 
   if (req.headers['content-length'] > 0) {
     try {
-      const parsedJson = await json(req)
+      const parsedJson = await json(req, { limit: limit })
       jsome(parsedJson)
       console.log('')
     } catch (err) {
@@ -88,13 +88,13 @@ const logResponse = async ({ res, end, endTime, requestIndex, chunk }) => {
 
 let requestCounter = 0
 
-const initLog = (req, res) => {
+const initLog = (req, res, limit) => {
   const start = new Date()
   const requestIndex = ++requestCounter
 
   console.log(chalk.grey(`\n${'—'.repeat(process.stdout.columns)}\n`))
 
-  const reqBodyReady = logRequest({ req, start, requestIndex })
+  const reqBodyReady = logRequest({ req, start, requestIndex, limit })
 
   const end = res.end
 
@@ -120,8 +120,8 @@ const initLog = (req, res) => {
   }
 }
 
-module.exports = fn => async (req, res) => {
-  initLog(req, res)
+module.exports = (fn, limit) => async (req, res) => {
+  initLog(req, res, limit)
 
   try {
     return await fn(req, res)

--- a/lib/log.js
+++ b/lib/log.js
@@ -37,7 +37,7 @@ const logRequest = async ({ req, start, requestIndex, limit }) => {
 
   if (req.headers['content-length'] > 0) {
     try {
-      const parsedJson = await json(req, { limit: limit })
+      const parsedJson = await json(req, { limit })
       jsome(parsedJson)
       console.log('')
     } catch (err) {

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -17,7 +17,7 @@ module.exports = async (file, flags, restarting) => {
   }
 
   // And then load the files
-  const module = flags.silent ? getModule(file) : log(getModule(file))
+  const module = flags.silent ? getModule(file) : log(getModule(file), flags.limit)
   const server = serve(module)
 
   // `3000` is the default port


### PR DESCRIPTION
**Issue**
Currently micro-dev will give an error respone if a request is larger than 1mb, due to the default of 1mb on the micro json parser. 


**Resolution**
Added a new flag `-l` or `--limit` to override the default of 1mb. 

---

Example use in package.json:
```
{ 
  scripts: {
    "dev": "micro-dev -l 5mb",
  }
}

```

Fixes #51 