### PR TITLE
Convert ignored string to regex

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -82,7 +82,7 @@ module.exports = async (server, inUse, flags, sockets) => {
 
     // Ignore globs
     if (flags.ignore) {
-      watchConfig.ignored = watchConfig.ignored.concat(flags.ignore)
+      watchConfig.ignored = watchConfig.ignored.concat(new RegExp(flags.ignore))
     }
 
     if (Array.isArray(toWatch)) {


### PR DESCRIPTION
I'm using JetBrains editor and I wanted to pass `--ignore .idea` to `micro-dev` and it would still restart server on every focus lost of the editor. To be able to really ignore the directory we'd need to convert `.idea` string into regex. This change solves my issue, but I'm not so sure about other use cases.