### PR TITLE
Automatically load `.env` files

### DIFF
--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -57,7 +57,7 @@ if (flags.version) {
 
 // Load the `.env` file
 dotEnv.config({
-  path: path.relative(process.cwd(), flags.dotenv)
+  path: path.resolve(process.cwd(), flags.dotenv)
 })
 
 if (flags.cold && (flags.watch || flags.poll)) {

--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -19,7 +19,7 @@ const flags = mri(process.argv.slice(2), {
     host: '::',
     port: 3000,
     limit: '1mb',
-    dotenv: path.join(process.cwd(), '.env')
+    dotenv: '.env'
   },
   alias: {
     p: 'port',
@@ -56,7 +56,9 @@ if (flags.version) {
 }
 
 // Load the `.env` file
-dotEnv.config({ path: flags.dotenv })
+dotEnv.config({
+  path: path.relative(process.cwd(), flags.dotenv)
+})
 
 if (flags.cold && (flags.watch || flags.poll)) {
   logError(

--- a/bin/micro-dev.js
+++ b/bin/micro-dev.js
@@ -6,6 +6,7 @@ const path = require('path')
 
 // Packages
 const mri = require('mri')
+const dotEnv = require('dotenv')
 
 // Utilities
 const generateHelp = require('../lib/help')
@@ -17,7 +18,8 @@ const flags = mri(process.argv.slice(2), {
   default: {
     host: '::',
     port: 3000,
-    limit: '1mb'
+    limit: '1mb',
+    dotenv: path.join(process.cwd(), '.env')
   },
   alias: {
     p: 'port',
@@ -29,7 +31,8 @@ const flags = mri(process.argv.slice(2), {
     h: 'help',
     v: 'version',
     i: 'ignore',
-    l: 'limit'
+    l: 'limit',
+    d: 'dotenv'
   },
   unknown(flag) {
     console.log(`The option "${flag}" is unknown. Use one of these:`)
@@ -51,6 +54,9 @@ if (flags.version) {
   console.log(version)
   process.exit()
 }
+
+// Load the `.env` file
+dotEnv.config({ path: flags.dotenv })
 
 if (flags.cold && (flags.watch || flags.poll)) {
   logError(

--- a/lib/help.js
+++ b/lib/help.js
@@ -8,6 +8,7 @@ module.exports = () => {
 
     ${g('-p, --port <n>')}      Port to listen on (defaults to 3000)
     ${g('-H, --host')}          The host on which micro will run
+    ${g('-d, --dotenv')}        Custom path for a .env file (relative to cwd)
     ${g('-c, --cold')}          Disable hot reloading
     ${g('-w, --watch <dir>')}   A directory to watch in addition to [path]
     ${g('-L, --poll')}          Poll for code changes rather than using events

--- a/package-lock.json
+++ b/package-lock.json
@@ -854,6 +854,11 @@
         "is-obj": "1.0.1"
       }
     },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -1154,9 +1159,9 @@
       }
     },
     "eslint-plugin-ava": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-4.3.0.tgz",
-      "integrity": "sha1-XRUggk2WpRC75Orw8S/jXyBKdJ4=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-4.4.0.tgz",
+      "integrity": "sha1-wYZuH2LnDa8re19gz7xTv+Jnpxc=",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
@@ -3220,7 +3225,7 @@
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
-        "rxjs": "5.5.3",
+        "rxjs": "5.5.5",
         "stream-to-observable": "0.2.0",
         "strip-ansi": "3.0.1"
       },
@@ -4062,9 +4067,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.1.tgz",
+      "integrity": "sha512-oYpQsZk7/0o8+YJUB0LfjkTYQa79gUIF2ESeqvG23IzcgqqvmeOE4+lMG7E/UKX3q3RIj8JHSfhrXWhon1L+zA==",
       "dev": true
     },
     "pretty-error": {
@@ -4454,18 +4459,18 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.3.tgz",
-      "integrity": "sha512-VWockSz7xmDveeZ7wv8RvdipGGZ1NmL/m4jnpvN9BH4x1fW/TPoD23yXh+qDkbWSlajXVVfLIbGmyxa94Ls84w==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.1.0"
+        "symbol-observable": "1.0.1"
       },
       "dependencies": {
         "symbol-observable": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-          "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
           "dev": true
         }
       }
@@ -5030,7 +5035,7 @@
         "eslint": "3.19.0",
         "eslint-config-xo": "0.18.2",
         "eslint-formatter-pretty": "1.3.0",
-        "eslint-plugin-ava": "4.3.0",
+        "eslint-plugin-ava": "4.4.0",
         "eslint-plugin-import": "2.8.0",
         "eslint-plugin-no-use-extend-native": "0.3.12",
         "eslint-plugin-promise": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chokidar": "1.7.0",
     "clipboardy": "1.2.2",
     "debounce": "1.1.0",
+    "dotenv": "4.0.0",
     "get-port": "3.2.0",
     "ip": "1.1.5",
     "jsome": "2.3.26",
@@ -57,7 +58,7 @@
     "eslint-config-prettier": "2.9.0",
     "husky": "0.14.3",
     "lint-staged": "6.0.0",
-    "prettier": "1.8.2",
+    "prettier": "1.9.1",
     "xo": "0.18.2"
   }
 }


### PR DESCRIPTION
This means we don't need to set up `dotenv` by ourselves or add the environment variables to the command line when running a command. Instead, micro-dev will handle it.

You can even pass a custom path: `micro-dev --dotenv <path-to-file>` 🚀 