### PR TITLE
Propagate `NODE_ENV` to other packages

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,3 +1,6 @@
+// Ensure that the loaded files and packages have the correct env
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+
 // Packages
 const getPort = require('get-port')
 const serve = require('micro/lib')
@@ -8,16 +11,15 @@ const listening = require('./listening')
 const log = require('./log')
 
 module.exports = async (file, flags, restarting) => {
-  // Ensure that the loaded files have the correct env
-  process.env.NODE_ENV = process.env.NODE_ENV || 'development'
-
   // Emit SIGNUSR2 to signal restart to user code
   if (restarting) {
     process.emit('SIGNUSR2')
   }
 
   // And then load the files
-  const module = flags.silent ? getModule(file) : log(getModule(file), flags.limit)
+  const module = flags.silent
+    ? getModule(file)
+    : log(getModule(file), flags.limit)
   const server = serve(module)
 
   // `3000` is the default port


### PR DESCRIPTION
this fixes https://github.com/zeit/micro-dev/issues/40 until the pretty printing is extracted from micro itself