### PR TITLE
Add .cache directory to default ignore

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -75,7 +75,7 @@ module.exports = async (server, inUse, flags, sockets) => {
       usePolling: flags.poll,
       ignoreInitial: true,
       ignored: [
-        /\.git|node_modules|\.nyc_output|\.sass-cache|coverage/,
+        /\.git|node_modules|\.nyc_output|\.sass-cache|coverage|\.cache/,
         /\.swp$/
       ]
     }


### PR DESCRIPTION
This is the cache directory used by https://parceljs.org/