### PR TITLE
Fix emitted signal when restarting

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -11,9 +11,8 @@ const listening = require('./listening')
 const log = require('./log')
 
 module.exports = async (file, flags, restarting) => {
-  // Emit SIGNUSR2 to signal restart to user code
   if (restarting) {
-    process.emit('SIGNUSR2')
+    process.emit('SIGUSR2')
   }
 
   // And then load the files


### PR DESCRIPTION
typo with `SIGNUSR2` it should be `SIGUSR2`, removed comment as obvious.