### PR TITLE
Support custom host in output message

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -136,7 +136,8 @@ module.exports = async (server, inUse, flags, sockets) => {
 
   message += '\n\n'
 
-  const localURL = `http://localhost:${details.port}`
+  const host = flags.host === '::' ? 'localhost' : flags.host;
+  const localURL = `http://${host}:${details.port}`
 
   message += `• ${chalk.bold('Local:           ')} ${localURL}\n`
   message += `• ${chalk.bold('On Your Network: ')} ${url}\n\n`


### PR DESCRIPTION
I changed to use ignored `flags.host` in "lib/listening.js". Could you merge this changes if there are no problems?

Before:
![before](https://user-images.githubusercontent.com/59784/38776053-b83efe6e-40cb-11e8-9b3a-866d02e0467d.png)

After:
![after](https://user-images.githubusercontent.com/59784/38776056-bd4f21e0-40cb-11e8-9716-646012f563a9.png)
