### PR TITLE
store request body after logging

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -38,6 +38,7 @@ const logRequest = async ({req, start, requestIndex, limit}) => {
 	if (req.headers['content-length'] > 0 && req.headers['content-type'].indexOf('application/json') === 0) {
 		try {
 			const parsedJson = await json(req, {limit});
+			req.body = parsedJson;
 			jsome(parsedJson);
 			console.log('');
 		} catch (err) {


### PR DESCRIPTION
This simple API works with `micro` but not `micro-dev`. I believe it has to do with how the logger is reading the body of the request. Without this change, the request hangs using `micro-dev`. By assigning the parsed JSON to the request, `express-graphql` can [use it later](https://github.com/graphql/express-graphql/blob/41e26f803f4bf6888a4dedf9af99153892d13eb4/src/parseBody.js#L28).

I understand this is a bit hacky and aimed at express middleware that doesn't take advantage of [multiple calls to `json`](https://github.com/zeit/micro/blob/c09975700ab721bd5b556d5467e9a6a929875470/lib/index.js#L112-L114). Is there another way to get `micro` and `micro-dev` behaving consistently?

```js
const graphqlHTTP = require("express-graphql");
const { buildSchema } = require("graphql");
const jwtAuth = require("micro-jwt-jwks-rsa-auth");

const schema = buildSchema(`
  type Query {
    random: Float!
  }
`);

const root = {
  random: () => Math.random()
};

const checkJwt = jwtAuth({
  jwksRsaConfig: {
    jwksUri: `https://your-project.auth0.com/.well-known/jwks.json`
  }
});

module.exports = checkJwt(graphqlHTTP({
  schema,
  rootValue: root
}));
```