### PR TITLE
Allow using micro-dev programmatically

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,59 @@
+// Ensure that the loaded files and packages have the correct env
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
+// Packages
+const serve = require('micro/lib');
+const ip = require('ip');
+const chalk = require('chalk');
+const boxen = require('boxen');
+
+// Utilities
+const log = require('./log');
+
+
+/**
+ * micro-dev for programmatic usage
+ *
+ * Usage:
+ *
+ * require('micro-dev')({ silent: false, limit: '1mb', host: '::', port: PORT })(handler)
+ */
+module.exports = flags => handler => {
+	const module = flags.silent ? handler : log(handler, flags.limit);
+	const server = serve(module);
+
+	const sockets = [];
+	server.on('connection', socket => {
+		const index = sockets.push(socket);
+		socket.once('close', () => sockets.splice(index, 1));
+	});
+
+	server.listen(flags.port, flags.host, err => {
+		if (err) {
+			console.error('micro:', err.stack);
+			process.exit(1);
+		}
+
+		// message
+		const details = server.address();
+		const ipAddress = ip.address();
+		const url = `http://${ipAddress}:${details.port}`;
+		let message = chalk.green('Micro is running programmatically!');
+		message += '\n\n';
+
+		const host = flags.host === '::' ? 'localhost' : flags.host;
+		const localURL = `http://${host}:${details.port}`;
+
+		message += `• ${chalk.bold('Local:           ')} ${localURL}\n`;
+		message += `• ${chalk.bold('On Your Network: ')} ${url}\n\n`;
+
+		const box = boxen(message, {
+			padding: 1,
+			borderColor: 'green',
+			margin: 1
+		});
+
+		// Print out the message
+		console.log(box);
+	});
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "micro-dev",
   "version": "3.0.0",
+  "main": "./lib/index.js",
   "files": [
     "bin",
     "lib"


### PR DESCRIPTION
Hi! I wanted to submit an idea I'm using myself with `ts-node-dev` in a TypeScript + (Apollo) GraphQL project where I use `micro` as my server library.


**Problem**

Using a `package.json` script such as the following:

```
"start": "ts-node-dev node_modules/.bin/micro-dev -p 4000 src/server.ts",
```

causes the process to crash on syntax errors etc. With `micro` this can be fixed by programmatically using micro:

```
# package.json
"start": "ts-node-dev src/server.ts"

# server.ts
const server = require('micro')(handler)
server.listen(PORT)
```

However, as we all know (https://github.com/zeit/micro/issues/337) `micro-dev` does not support programmatical usage. While many of the features are CLI specific, some are not. 

**Solution**

With this PR in place, one can do something like:

```
const PORT = process.env.PORT || 4000

if (process.env.NODE_ENV === 'development') {
  const microDev = require('micro-dev')
  microDev({ silent: false, limit: '1mb', host: '::', port: PORT })(handler)
} else {
  const server = require('micro')(handler)
  server.listen(PORT)
}
```

**Comments**

* you guys might prefer https://github.com/zeit/micro/issues/337#issuecomment-365670943
* the message part breaks DRY but we can clean that up if this direction feels correct
* we're not really supporting too many micro-dev features
* it might make sense to **not** call `.listen` within `micro-dev` when using the library like this. It would make this PR simpler and the usage a bit cleaner:
```
const server = require('micro')(handler)
if (process.env.NODE_ENV === 'development') {
  server = require('micro-dev')({ silent: false, limit: '1mb'})(handler)
}
server.listen(PORT)
```

It nothing else, this might act as a good reference for other micro & TypeScript users! 

Cheers :)

