### PR TITLE
Use `npm run` consistently throughout README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The package can be used in conjunction with the Node.js inspector like this:
 As the final step, start the development server like this:
 
 ```bash
-yarn run inspect
+npm run inspect
 ```
 
 ## Contributing


### PR DESCRIPTION
I was reading through the README and noticed that one of the command examples uses `yarn run` instead of `npm run` (like all others examples). Not that I have anything against yarn, but it feels better to be consistent about this throughout the document.