### PR TITLE
Check existence of content-type header before using indexOf

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -23,7 +23,7 @@ jsome.colors = {
 const logLine = (message, date) => {
 	const dateString = `${chalk.grey(date.toLocaleTimeString())}`;
 	let logSpace =
-    process.stdout.columns - stringLength(message) - stringLength(dateString);
+		process.stdout.columns - stringLength(message) - stringLength(dateString);
 
 	if (logSpace <= 0) {
 		logSpace = 10;
@@ -35,7 +35,11 @@ const logLine = (message, date) => {
 const logRequest = async ({req, start, requestIndex, limit}) => {
 	logLine(`> #${requestIndex} ${chalk.bold(req.method)} ${req.url}`, start);
 
-	if (req.headers['content-length'] > 0 && req.headers['content-type'].indexOf('application/json') === 0) {
+	if (
+		req.headers['content-length'] > 0 &&
+		req.headers['content-type'] &&
+		req.headers['content-type'].indexOf('application/json') === 0
+	) {
 		try {
 			const parsedJson = await json(req, {limit});
 			jsome(parsedJson);
@@ -103,7 +107,7 @@ const initLog = (req, res, limit) => {
 		const endTime = new Date();
 		const delta = endTime - start;
 		const requestTime =
-      delta < 10000 ? `${delta}ms` : `${Math.round(delta / 1000)}s`;
+			delta < 10000 ? `${delta}ms` : `${Math.round(delta / 1000)}s`;
 
 		reqBodyReady.then(() =>
 			logResponse({


### PR DESCRIPTION
Closes #94 
- prevents an unhandled promise exception from being thrown when a
content type isn't provided.