### PR TITLE
Show friendly error if 'micro' peer dependency isn't met

### DIFF
--- a/errors/micro-not-installed.md
+++ b/errors/micro-not-installed.md
@@ -1,0 +1,13 @@
+# `micro` Isn't Installed As A Peer Dependency
+
+#### Why This Error Occurred
+
+`micro-dev` expects `micro` to be installed as well. It doesn't install its own copy, or duplicate the utility of `micro`! Since projects using `micro-dev` will typically use `micro` in production depending on it as a peer helps avoid unexpected changes in behavior later.
+
+#### Possible Ways to Fix It
+
+##### Install `micro` as a dependency
+`npm install micro` in your project. If you intend to use `micro` in production (e.g. to power a microservice) you'll need to do this eventually anyway.
+
+##### Install `micro` as a dev dependency
+`npm install --save-dev micro` in your project. If you're using `micro` strictly as a development utility (e.g. to locally simulate configured logic later managed by a builder, like `now.json` routes) then consider `micro` as a dev dependency.

--- a/lib/error.js
+++ b/lib/error.js
@@ -2,7 +2,7 @@
 const {red, blue} = require('chalk');
 
 module.exports = (message, errorCode) => {
-	const repo = errorCode === 'watch-flags' ? 'micro-dev' : 'micro';
+	const repo = ['watch-flags', 'micro-not-installed'].includes(errorCode) ? 'micro-dev' : 'micro';
 
 	console.error(`${red('Error:')} ${message}`);
 	console.error(`${blue('How to Fix It:')} https://err.sh/${repo}/${errorCode}`);

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,6 +1,15 @@
 // Ensure that the loaded files and packages have the correct env
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
+// Confirm peer dependency is installed
+try {
+	require.resolve('micro/lib');
+} catch (err) {
+	const logError = require('../lib/error');
+	logError('\'micro\' needs to be installed as a peer dependency', 'micro-not-installed');
+	process.exit(1);
+}
+
 // Packages
 const getPort = require('get-port');
 const serve = require('micro/lib');


### PR DESCRIPTION
I got too excited to use `micro-dev` and installed it without regarding the `npm WARN` about my unmet `micro` peer dependency. The resulting `Cannot find module 'micro/lib'` error didn't spark an immediate understanding of the fix.

This change validates the availability of `micro`, and provides a friendlier error if it's missing.

I'd meant to use `micro-dev` to simulate Now V2's routing (starting from [this comment](https://github.com/zeit/now-cli/issues/1681#issuecomment-449610654))—since this was only in a development context I hadn't made a point of installing `micro` too. Although my error required a a few willful missteps on my part, my mistakes feel like the sort that other devs getting comfortable with `micro-dev` could make.